### PR TITLE
Add valgrind for cucumber testing

### DIFF
--- a/aarch64/runners/c++/Dockerfile
+++ b/aarch64/runners/c++/Dockerfile
@@ -9,7 +9,8 @@ RUN [ "cross-build-start" ]
 RUN apt-get update && \
     apt-get install -y make cucumber libboost-test-dev \
     libboost-thread-dev libboost-system-dev libboost-regex-dev \
-    libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev && \
+    libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev \
+    valgrind netcat && \
     apt-get clean
 
 RUN [ "cross-build-end" ]

--- a/aarch64/runners/c++/Dockerfile
+++ b/aarch64/runners/c++/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     apt-get install -y make cucumber libboost-test-dev \
     libboost-thread-dev libboost-system-dev libboost-regex-dev \
     libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev \
-    valgrind netcat && \
+    valgrind && \
     apt-get clean
 
 RUN [ "cross-build-end" ]

--- a/amd64/clang/Dockerfile
+++ b/amd64/clang/Dockerfile
@@ -5,7 +5,7 @@ LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
 RUN apt-get update && apt-get install -y clang libboost-test-dev \
     libboost-thread-dev libboost-system-dev libboost-regex-dev \
     libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev cucumber cmake \
-    valgrind netcat && \
+    valgrind && \
     apt-get clean
 
 ENV CC=clang

--- a/amd64/clang/Dockerfile
+++ b/amd64/clang/Dockerfile
@@ -4,7 +4,8 @@ LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
 
 RUN apt-get update && apt-get install -y clang libboost-test-dev \
     libboost-thread-dev libboost-system-dev libboost-regex-dev \
-    libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev cucumber cmake && \
+    libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev cucumber cmake \
+    valgrind netcat && \
     apt-get clean
 
 ENV CC=clang

--- a/amd64/gcc/Dockerfile
+++ b/amd64/gcc/Dockerfile
@@ -5,7 +5,7 @@ LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
 RUN apt-get update && apt-get install -y g++ libboost-test-dev \
     libboost-thread-dev libboost-system-dev libboost-regex-dev \
     libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev cucumber cmake \
-    valgrind netcat && \
+    valgrind && \
     apt-get clean
 
 ENV CC=gcc

--- a/amd64/gcc/Dockerfile
+++ b/amd64/gcc/Dockerfile
@@ -4,7 +4,8 @@ LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
 
 RUN apt-get update && apt-get install -y g++ libboost-test-dev \
     libboost-thread-dev libboost-system-dev libboost-regex-dev \
-    libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev cucumber cmake && \
+    libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev cucumber cmake \
+    valgrind netcat && \
     apt-get clean
 
 ENV CC=gcc

--- a/armhf/runners/c++/Dockerfile
+++ b/armhf/runners/c++/Dockerfile
@@ -9,7 +9,8 @@ RUN [ "cross-build-start" ]
 RUN apt-get update && \
     apt-get install -y make cucumber libboost-test-dev \
     libboost-thread-dev libboost-system-dev libboost-regex-dev \
-    libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev && \
+    libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev \
+    valgrind netcat && \
     apt-get clean
 
 RUN [ "cross-build-end" ]

--- a/armhf/runners/c++/Dockerfile
+++ b/armhf/runners/c++/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     apt-get install -y make cucumber libboost-test-dev \
     libboost-thread-dev libboost-system-dev libboost-regex-dev \
     libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev \
-    valgrind netcat && \
+    valgrind && \
     apt-get clean
 
 RUN [ "cross-build-end" ]

--- a/i386/clang/Dockerfile
+++ b/i386/clang/Dockerfile
@@ -4,7 +4,8 @@ LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
 
 RUN apt-get update && apt-get install -y clang make libboost-test-dev \
     libboost-thread-dev libboost-system-dev libboost-regex-dev \
-    libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev cucumber cmake && \
+    libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev cucumber cmake \
+    valgrind netcat && \
     apt-get clean
 
 ENV CC=clang

--- a/i386/clang/Dockerfile
+++ b/i386/clang/Dockerfile
@@ -5,7 +5,7 @@ LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
 RUN apt-get update && apt-get install -y clang make libboost-test-dev \
     libboost-thread-dev libboost-system-dev libboost-regex-dev \
     libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev cucumber cmake \
-    valgrind netcat && \
+    valgrind && \
     apt-get clean
 
 ENV CC=clang

--- a/i386/gcc/Dockerfile
+++ b/i386/gcc/Dockerfile
@@ -4,7 +4,8 @@ LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
 
 RUN apt-get update && apt-get install -y g++ make libboost-test-dev \
     libboost-thread-dev libboost-system-dev libboost-regex-dev \
-    libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev cucumber cmake && \
+    libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev cucumber cmake \
+    valgrind netcat && \
     apt-get clean
 
 ENV CC=gcc

--- a/i386/gcc/Dockerfile
+++ b/i386/gcc/Dockerfile
@@ -5,7 +5,7 @@ LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
 RUN apt-get update && apt-get install -y g++ make libboost-test-dev \
     libboost-thread-dev libboost-system-dev libboost-regex-dev \
     libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev cucumber cmake \
-    valgrind netcat && \
+    valgrind && \
     apt-get clean
 
 ENV CC=gcc


### PR DESCRIPTION
# Description

Add the valgrind package to docker images susceptibles to run cucumber tests.

Functional tests will soon run under the supervision of valgrind, whose reports will be analyzed by the CI. The aim is to make the CI fail if errors are found
